### PR TITLE
fix: ci node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
-      - name: Use Node.js 14.x
+      - name: Use Node.js 15.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 15.x
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.34-canary.3.f6aff1f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dylandepass/franklin-storybook-addon@0.0.34-canary.3.f6aff1f.0
  # or 
  yarn add @dylandepass/franklin-storybook-addon@0.0.34-canary.3.f6aff1f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
